### PR TITLE
Make "download numbers" more accesible

### DIFF
--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -178,10 +178,10 @@ const strings = {
             <dl id="episode-pacing-legend" class="grid grid-cols-[3rem_1fr_0_0_0_auto] md:grid-cols-[3rem_1fr_auto_auto_auto_auto] gap-x-2 cursor-pointer text-xs md:text-sm">
                 <dt></dt>
                 <dd></dd>
-                <div class="text-right text-xs opacity-50 mr-2 mb-1 invisible md:visible">${s:3_day:'3-day'}</div>
-                <div class="text-right text-xs opacity-50 mr-2 invisible md:visible">${s:7_day:'7-day'}</div>
-                <div class="text-right text-xs opacity-50 mr-2 invisible md:visible">${s:30_day:'30-day'}</div>
-                <div class="text-right text-xs opacity-50 mr-2">${s:all_time:'all-time'}</div>
+                <div id="epl-3-day" class="text-right text-xs opacity-50 mr-2 mb-1 invisible md:visible">${s:3_day:'3-day'}</div>
+                <div id="epl-7-day" class="text-right text-xs opacity-50 mr-2 invisible md:visible">${s:7_day:'7-day'}</div>
+                <div id="epl-30-day" class="text-right text-xs opacity-50 mr-2 invisible md:visible">${s:30_day:'30-day'}</div>
+                <div id="epl-all-time" class="text-right text-xs opacity-50 mr-2">${s:all_time:'all-time'}</div>
 
                 <div id="episode-pacing-nav" class="flex items-center justify-center gap-2 mt-4 mb-8 col-span-6">
                     <sl-icon-button class="invisible" name="download"></sl-icon-button>
@@ -196,10 +196,10 @@ const strings = {
             <template id="episode-pacing-legend-item">
                 <dt></dt>
                 <dd class="leading-relaxed truncate mr-2" lang="">Item</dd>
-                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible">123</div>
-                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible">123</div>
-                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible">123</div>
-                <div class="downloads-all text-right font-mono opacity-50 mr-2">123</div>
+                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-3-day">123</div>
+                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-7-day">123</div>
+                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible aria-labelledby="epl-30-day"">123</div>
+                <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-labelledby="epl-all-time">123</div>
             </template>
         </div>
 


### PR DESCRIPTION
As asked by a blind person using OP3
I think that these changes doesn't break anything visually

Another option would be to use just `aria-label`, but if works as I expect, `aria-labelledby` would be more multi-language friendly.

PD: No way to test this first. Is there any stage/test environment?