### PR TITLE
Test 2 different a11y options w/o ids

### DIFF
--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -196,9 +196,9 @@ const strings = {
             <template id="episode-pacing-legend-item">
                 <dt></dt>
                 <dd class="leading-relaxed truncate mr-2" lang="">Item</dd>
-                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-3-day">123</div>
+                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-describedby="epl-3-day">123</div>
                 <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-7-day">123</div>
-                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-30-day">123</div>
+                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="30d">123</div>
                 <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-labelledby="epl-all-time">123</div>
             </template>
         </div>


### PR DESCRIPTION
The string "123" is replaced in all the template or just when it's on the `<div>content</div>`? To know if it could be used on the a arial-*="123 epl-3-day"