### PR TITLE
Use aria-description as temporal solution

### DIFF
--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -196,10 +196,10 @@ const strings = {
             <template id="episode-pacing-legend-item">
                 <dt></dt>
                 <dd class="leading-relaxed truncate mr-2" lang="">Item</dd>
-                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-describedby="epl-3-day">123</div>
-                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-labelledby="epl-7-day">123</div>
-                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="30d">123</div>
-                <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-labelledby="epl-all-time">123</div>
+                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:3_day:'3-day'}">123</div>
+                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:7_day:'7-day'}">123</div>
+                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:30_day:'30-day'}">123</div>
+                <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-description="${s:all_time:'all-time'}">123</div>
             </template>
         </div>
 

--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -196,10 +196,10 @@ const strings = {
             <template id="episode-pacing-legend-item">
                 <dt></dt>
                 <dd class="leading-relaxed truncate mr-2" lang="">Item</dd>
-                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:3_day:'3-day'}">123</div>
-                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:7_day:'7-day'}">123</div>
-                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:30_day:'30-day'}">123</div>
-                <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-description="${s:all_time:'all-time'}">123</div>
+                <div class="downloads-3 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:3_day:''}">123</div>
+                <div class="downloads-7 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:7_day:''}">123</div>
+                <div class="downloads-30 text-right font-mono opacity-50 mr-2 invisible md:visible" aria-description="${s:30_day:''}">123</div>
+                <div class="downloads-all text-right font-mono opacity-50 mr-2" aria-description="${s:all_time:''}">123</div>
             </template>
         </div>
 


### PR DESCRIPTION
`aria-description` seems to work out of the box in most screen readers. `aria-describedby` would be better but it doesn't work in no interactive elements. `tabindex=0` would make it "focusable" and readable but it's a bad practice.

TODO: Try to make the `dl` in to a real table that already has all the accessibility built in.
I will try first to do the quick and easy fixes in ay11 and if you can set instructions to have a local dev environment, I would try the table approach, as that is too much for my coding skills right now.