### PR TITLE
a11y: Indicate links that open in new window

### DIFF
--- a/worker/routes/show.ts
+++ b/worker/routes/show.ts
@@ -114,7 +114,7 @@ export async function computeShowResponse(req: ShowRequest, opts: Opts): Promise
         ogTags: computeOgTags({ ogImageRes, showTitleWithSuffix, showUuid, origin, searchParams, showTitle }),
         initialData,
         styleTag: computeStyleTag(),
-        shoelaceCommon: computeShoelaceCommon('sl-card', 'sl-spinner', 'sl-icon-button', 'sl-button-group', 'sl-button', 'sl-dropdown', 'sl-menu', 'sl-menu-item', 'sl-switch', 'sl-icon', 'sl-relative-time', 'data-loaded'),
+        shoelaceCommon: computeShoelaceCommon('sl-card', 'sl-spinner', 'sl-icon-button', 'sl-button-group', 'sl-button', 'sl-dropdown', 'sl-menu', 'sl-menu-item', 'sl-switch', 'sl-icon', 'sl-relative-time', 'data-loaded', 'sl-visually-hidden'),
         nonProdHeader: computeNonProdHeader(instance, productionOrigin),
         cfAnalyticsSnippet: computeCloudflareAnalyticsSnippet(cfAnalyticsToken),
         origin,

--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -42,6 +42,7 @@ const strings = {
     tz_is_equal_to_utc: "${s:tz_is_equal_to_utc:'%s is equal to %s'}",
     tz_is_behind_utc: "${s:tz_is_behind_utc:'%s is %s behind %s'}",
     tz_is_ahead_of_utc: "${s:tz_is_ahead_of_utc:'%s is %s ahead of %s'}",
+    open_in_new_window: "${s:open_in_new_window:'opens in a new window'}",
 };
 /*${appJs}*/
     </script>
@@ -113,7 +114,7 @@ const strings = {
             </sl-card>
         </div>
 
-        <div class="flex justify-center items-center mt-8"><a class="text-neutral-600 text-sm md:text-base localized" href="/download-calculation" target="_blank">${s:how_op3_calculates_downloads:'How OP3 calculates downloads'} →</a></div>
+        <div class="flex justify-center items-center mt-8"><a class="text-neutral-600 text-sm md:text-base localized" href="/download-calculation" target="_blank">${s:how_op3_calculates_downloads:'How OP3 calculates downloads'} →<sl-visually-hidden>${s:open_in_new_window:''}</sl-visually-hidden></a></div>
 
         <!-- downloads graph -->
         <div class="flex justify-center items-center mt-16 leading-none text-sm md:text-base">
@@ -146,11 +147,11 @@ const strings = {
                     <p><span id="listens-25" class="font-bold">xx%</span> ${s:of_listeners_listen_to:'of listeners listen to at least'} <span class="font-bold">25%</span> ${s:of_an_episode:'of an episode'}</p>
                     <p><span id="listens-50" class="font-bold">xx%</span> ${s:of_listeners_listen_to:''} <span class="font-bold">${s:half:'half'}</span></p>
                     <p><span id="listens-90" class="font-bold">xx%</span> ${s:of_listeners_listen_to:''} <span class="font-bold">90%</span></p>
-                    <template id="listens-from-app"><span>n</span> ${s:from:'from'} <a href="#" class="text-neutral-600 app-name" target="_blank">app</a></template>
+                    <template id="listens-from-app"><span>n</span> ${s:from:'from'} <a href="#" class="text-neutral-600 app-name" target="_blank">app<sl-visually-hidden>${s:open_in_new_window:''}</sl-visually-hidden></a></template>
                     <div id="listens-based-on" class="text-neutral-600 mt-4 text-sm leading-relaxed">${s:based_on:'Based on'} <span id="listens-count">nn</span> ${s:anonymized_playback_sessions:'anonymized playback sessions'}: </div>
                 </sl-card>
             </div>
-            <div class="flex justify-center items-center mt-8 text-sm md:text-base"><a class="text-neutral-600" href="/listen-time-calculation" target="_blank">${s:how_op3_calculates_listen_time:'How OP3 calculates client-side listen time'} →</a></div>
+            <div class="flex justify-center items-center mt-8 text-sm md:text-base"><a class="text-neutral-600" href="/listen-time-calculation" target="_blank">${s:how_op3_calculates_listen_time:'How OP3 calculates client-side listen time'} →<sl-visually-hidden>${s:open_in_new_window:''}</sl-visually-hidden></a></div>
             <div>
                 <canvas id="listens-graph" class="max-h-64 cursor-pointer hidden mt-8"></canvas>
             </div>


### PR DESCRIPTION
New translatable string needed
open_in_new_window: "${s:open_in_new_window:'opens in a new window'}",

Just on aria in this first PR. But it's also recommended to use a icon like <sl-icon name="box-arrow-up-right"></sl-icon>