### PR TITLE
a11y: workaround tooltip shoelace bug

### DIFF
--- a/worker/static/show.htm
+++ b/worker/static/show.htm
@@ -66,7 +66,7 @@ const strings = {
                     <canvas id="seven-day-downloads-sparkline" class="max-h-[1.5rem] max-w-[11rem] opacity-75 cursor-pointer grow"></canvas>
                     <sl-tooltip style="--sl-tooltip-arrow-size: 0;">
                         <div class="text-xs" slot="content">${s:download_sparkline_info:days=7:'Total number of downloads for this podcast in the last %d days, and a graph showing the recent history of this value.'}<br><br>${s:download_definition_info:'In OP3, a download is defined as a unique GET request per IP hash within a 24-hr period (UTC day) from a non-bot user agent.'}</div>
-                        <sl-icon name="info-circle" label="Info" class="cursor-pointer opacity-50"></sl-icon>
+                        <sl-icon name="info-circle" label="Info;${s:download_sparkline_info:days=7:''}. ${s:download_definition_info:''}" class="cursor-pointer opacity-50"></sl-icon>
                     </sl-tooltip>
                 </div>
             </sl-card>
@@ -79,7 +79,7 @@ const strings = {
                     <canvas id="thirty-day-downloads-sparkline" class="max-h-[1.5rem] max-w-[11rem] opacity-75 cursor-pointer grow"></canvas>
                     <sl-tooltip style="--sl-tooltip-arrow-size: 0;">
                         <div class="text-xs" slot="content">${s:download_sparkline_info:days=30:''}<br><br>${s:download_definition_info:''}</div>
-                        <sl-icon name="info-circle" label="Info" class="cursor-pointer opacity-50"></sl-icon>
+                        <sl-icon name="info-circle" label="Info;${s:download_sparkline_info:days=30:''}" class="cursor-pointer opacity-50"></sl-icon>
                     </sl-tooltip>
                 </div>
             </sl-card>
@@ -93,7 +93,7 @@ const strings = {
                     <canvas id="downloads-minigraph" class="max-h-[1.5rem] max-w-[11rem] opacity-75 cursor-pointer grow"></canvas>
                     <sl-tooltip style="--sl-tooltip-arrow-size: 0;">
                         <div class="text-xs" slot="content">${s:monthly_downloads_info:'Downloads for this podcast in a given month.'}</div>
-                        <sl-icon name="info-circle" label="Info" class="cursor-pointer opacity-50"></sl-icon>
+                        <sl-icon name="info-circle" label="Info;${s:monthly_downloads_info:''" class="cursor-pointer opacity-50"></sl-icon>
                     </sl-tooltip>
                 </div>
             </sl-card>
@@ -107,7 +107,7 @@ const strings = {
                     <canvas id="audience-minigraph" class="max-h-[1.5rem] max-w-[11rem] opacity-75 cursor-pointer grow"></canvas>
                     <sl-tooltip style="--sl-tooltip-arrow-size: 0;">
                         <div class="text-xs" slot="content">${s:audience_info:'Unique listeners (IP hash) for this podcast in a given month.'}<br><br>${s:audience_definition_info:'OP3 rotates listener IP hashes every month for privacy reasons.'}</div>
-                        <sl-icon name="info-circle" label="Info" class="cursor-pointer opacity-50"></sl-icon>
+                        <sl-icon name="info-circle" label="Info;${s:audience_info:''}. ${s:audience_definition_info:''}" class="cursor-pointer opacity-50"></sl-icon>
                     </sl-tooltip>
                 </div>
             </sl-card>


### PR DESCRIPTION
Not the best use of `aria-label`. But I think it will do.